### PR TITLE
TECH : allow event attendees to modify the event if necessary

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -48,6 +48,7 @@ func main() {
 			},
 			Summary: session.GetDisplayName(),
 			Attendees: attendees,
+			GuestsCanModify: true,
 		}).Do()
 		util.PanicOnError(err, "Can't create event")
 		logger.Info("✔ " + session.GetDisplayName())


### PR DESCRIPTION
This PR add a new parameter `guestsCanModify` to the event creation so that reviewers are allowed to modify the event, in order to re-plan it later, etc.