### PR TITLE
TECH Add maxsessionsperweek and skills optional fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Format example:
   maxsessionsperweek: 1
 - email: obi-wan.kenobi@kapten.com
 ```
-**isgoodreviewer** is used to distinguish the experienced reviewers in order to create reviewer pairs that contain at least one experienced reviewer.
-**maxsessionsperweek** is optional, default is 3. If set to 0, it also falls back to the default value.
-**skills** describes the areas of expertise of a reviewer in order to create pairs of people with same competences. If not specified the reviewer can be paired with any other reviewer (no matter the skills)
+**isgoodreviewer** [optional] is used to distinguish the experienced reviewers in order to create reviewer pairs that contain at least one experienced reviewer. Default value is false.
+**maxsessionsperweek** [optional] sets a custom max sessions number per week for a reviewer. Default is 3. If set to 0, it also falls back to the default value.
+**skills** [optional] describes the areas of expertise of a reviewer in order to create pairs of people with same competences. If not specified the reviewer can be paired with any other reviewer (no matter the skills)
 
 You need to create/retrieve a `client_secret.json` file containing a valid Google Calendar
 access token for Kapten's calendar.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,23 @@ Matchmaker takes care of matching and planning of reviewers and review slots in 
 ## Setup
 
 You need to retrieve the `persons.yml` file containing people configuration for review.
+Format example:
+```yaml
+- email: john.doe@kapten.com
+  isgoodreviewer: true
+- email: chuck.norris@kapten.com
+  isgoodreviewer: true
+  maxsessionsperweek: 1
+- email: james.bond@kapten.com
+- email: john.wick@kapten.com
+  maxsessionsperweek: 1
+- email: obi-wan.kenobi@kapten.com
+```
+**isgoodreviewer** is used to distinguish the experienced reviewers in order to create reviewer pairs that contain at least one experienced reviewer.
+**maxsessionsperweek** is optional, default is 3. If set to 0, it also falls back to the default value.
 
 You need to create/retrieve a `client_secret.json` file containing a valid Google Calendar
-access token for Chauffeur Privé's calendar.
+access token for Kapten's calendar.
 
 Those files need to be placed at the root of the project.
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,15 @@ Format example:
 ```yaml
 - email: john.doe@kapten.com
   isgoodreviewer: true
+  skills:
+    - frontend
+    - backend
 - email: chuck.norris@kapten.com
   isgoodreviewer: true
   maxsessionsperweek: 1
+  skills:
+    - frontend
+    - data
 - email: james.bond@kapten.com
 - email: john.wick@kapten.com
   maxsessionsperweek: 1
@@ -19,6 +25,7 @@ Format example:
 ```
 **isgoodreviewer** is used to distinguish the experienced reviewers in order to create reviewer pairs that contain at least one experienced reviewer.
 **maxsessionsperweek** is optional, default is 3. If set to 0, it also falls back to the default value.
+**skills** describes the areas of expertise of a reviewer in order to create pairs of people with same competences. If not specified the reviewer can be paired with any other reviewer (no matter the skills)
 
 You need to create/retrieve a `client_secret.json` file containing a valid Google Calendar
 access token for Kapten's calendar.

--- a/match/config.go
+++ b/match/config.go
@@ -8,7 +8,7 @@ var durations = []time.Duration{
 
 var minSessionSpacing = time.Hour * 8
 
-var maxSessionsPerWeek = 3
+var defaultMaxSessionsPerWeek = 3
 
 var maxWidthExploration = 2
 

--- a/match/problem.go
+++ b/match/problem.go
@@ -6,9 +6,10 @@ import (
 )
 
 type Person struct {
-	Email                           string `yaml:"email"`
-	IsGoodReviewer                  bool
-	isSessionCompatibleSessionCount int `yaml:"-"`
+	Email                           string 	`yaml:"email"`
+	IsGoodReviewer                  bool		`yaml:"isgoodreviewer"`
+	MaxSessionsPerWeek              int			`yaml:"maxsessionsperweek"`
+	isSessionCompatibleSessionCount int 		`yaml:"-"`
 }
 
 func LoadPersons(path string) ([]*Person, error) {

--- a/match/problem.go
+++ b/match/problem.go
@@ -6,10 +6,11 @@ import (
 )
 
 type Person struct {
-	Email                           string 	`yaml:"email"`
-	IsGoodReviewer                  bool		`yaml:"isgoodreviewer"`
-	MaxSessionsPerWeek              int			`yaml:"maxsessionsperweek"`
-	isSessionCompatibleSessionCount int 		`yaml:"-"`
+	Email                           string    `yaml:"email"`
+	IsGoodReviewer                  bool      `yaml:"isgoodreviewer"`
+	MaxSessionsPerWeek              int       `yaml:"maxsessionsperweek"`
+	Skills                          []string  `yaml:"skills"`
+	isSessionCompatibleSessionCount int       `yaml:"-"`
 }
 
 func LoadPersons(path string) ([]*Person, error) {

--- a/match/solver.go
+++ b/match/solver.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"sort"
 	"github.com/transcovo/go-chpr-logger"
+	"github.com/transcovo/matchmaker/util"
 	"github.com/sirupsen/logrus"
 	"strings"
 	"fmt"
@@ -194,6 +195,11 @@ func isSessionCompatible(session *ReviewSession, sessions []*ReviewSession) bool
 		otherReviewers := otherSession.Reviewers
 		// not the same squad
 		if reviewers == otherReviewers {
+			return false
+		}
+
+		// not the same skills (if no skills specified, the reviewer can pair with any other reviewer)
+		if len(person0.Skills) != 0 && len(person1.Skills) != 0 && len(util.Intersection(person0.Skills, person1.Skills)) == 0 {
 			return false
 		}
 

--- a/match/solver.go
+++ b/match/solver.go
@@ -164,7 +164,7 @@ func getSolver(problem *Problem, allSessions []*ReviewSession) solver {
 
 		return bestSessions, bestCoveragePerformance
 	}
-	return solve;
+	return solve
 }
 
 func missingCoverageToString(missingCoverage int) string {
@@ -213,9 +213,17 @@ func isSessionCompatible(session *ReviewSession, sessions []*ReviewSession) bool
 		otherPerson1.isSessionCompatibleSessionCount += 1
 	}
 
-	// max 4 reviews per person
-	return person0.isSessionCompatibleSessionCount < maxSessionsPerWeek &&
-		person1.isSessionCompatibleSessionCount < maxSessionsPerWeek
+	// check the max reviews per person
+  maxSessionsForPerson0 := defaultMaxSessionsPerWeek
+  maxSessionsForPerson1 := defaultMaxSessionsPerWeek
+  if person0.MaxSessionsPerWeek != 0 {
+		maxSessionsForPerson0 = person0.MaxSessionsPerWeek
+  }
+  if person1.MaxSessionsPerWeek != 0 {
+    maxSessionsForPerson1 = person1.MaxSessionsPerWeek
+  }
+  return person0.isSessionCompatibleSessionCount < maxSessionsForPerson0 &&
+    person1.isSessionCompatibleSessionCount < maxSessionsForPerson1
 }
 
 func printRanges(ranges []*Range) {

--- a/match/solver.go
+++ b/match/solver.go
@@ -198,7 +198,7 @@ func isSessionCompatible(session *ReviewSession, sessions []*ReviewSession) bool
 			return false
 		}
 
-		// not the same skills (if no skills specified, the reviewer can pair with any other reviewer)
+		// not the same skills (if no skills specified, the reviewer can be paired with any other reviewer)
 		if len(person0.Skills) != 0 && len(person1.Skills) != 0 && len(util.Intersection(person0.Skills, person1.Skills)) == 0 {
 			return false
 		}

--- a/util/util.go
+++ b/util/util.go
@@ -9,3 +9,23 @@ func PanicOnError(err error, message string) {
 		logger.GetLogger().WithError(err).Fatal(message)
 	}
 }
+
+func Intersection(array1 []string, array2 []string) []string {
+	commonItems := []string{}
+	for i := 0; i < len(array1); i++ {
+		element := array1[i]
+		if contains(array2, element) {
+			commonItems = append(commonItems, element)
+		}
+	}
+	return commonItems
+}
+
+func contains(array []string, element string) bool {
+	for i := 0; i < len(array); i++ {
+		if array[i] == element {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This PR aims at adding 2 optional fields:
- **maxsessionsperweek**: to be able to fix a max number of sessions per reviewer and per week. By default it's 3 as it already was
```yaml
- email: chuck.norris@kapten.com
  maxsessionsperweek: 1
```
- **skills**: that allows to pair people with same competences. For example a reviewer with `frontend` skill won't be paired with a `backend` guy. If no skill is specified, the reviewer can be paired with anyone.
```yaml
- email: john.doe@kapten.com
  skills:
    - backend
    - data
```